### PR TITLE
Scope the ecosystem docs to the released package set

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorDocsNext"
 uuid = "701fd796-f527-45da-9a53-2681c1a90c45"
-version = "0.1.16"
+version = "0.1.17"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -26,7 +26,9 @@ Documenter.makedocs(;
     modules = [ITensorDocsNext],
     warnonly = true,
     format = Documenter.HTML(; assets = ["assets/favicon.ico", "assets/extras.css"]),
-    pages = ["index.md", "ecosystem_overview.md", "upgrade_guide.md"]
+    # `upgrade_guide.md` is kept in source but left out of the nav until it gets a
+    # rewrite to match the current next-generation API.
+    pages = ["index.md", "ecosystem_overview.md"]
 )
 
 @info "Building aggregate ITensorDocsNext site"
@@ -50,36 +52,21 @@ docs = [
         "Tensor Network Libraries", itensor_multidocref.(["ITensorNetworksNext"])
     ),
     MultiDocumenter.DropdownNav(
-        "Array Libraries",
+        "Tensor Libraries",
         itensor_multidocref.(
             [
                 "ITensorBase",
-                "NamedDimsArrays",
                 "TensorAlgebra",
-                "BlockSparseArrays",
+                "GradedArrays",
                 "SparseArraysBase",
-                "DiagonalArrays",
-                "KroneckerArrays",
             ]
         )
-    ),
-    MultiDocumenter.DropdownNav(
-        "Symmetric Tensors", itensor_multidocref.(["FusionTensors", "GradedArrays"])
     ),
     MultiDocumenter.DropdownNav(
         "Graph Libraries", itensor_multidocref.(["NamedGraphs", "DataGraphs"])
     ),
     MultiDocumenter.DropdownNav(
-        "Developer Tools",
-        itensor_multidocref.(
-            [
-                "FunctionImplementations",
-                "TypeParameterAccessors",
-                "MapBroadcast",
-                "BackendSelection",
-                "ITensorPkgSkeleton",
-            ]
-        )
+        "Developer Tools", itensor_multidocref.(["ITensorPkgSkeleton"])
     ),
 ]
 

--- a/docs/src/ecosystem_overview.md
+++ b/docs/src/ecosystem_overview.md
@@ -5,15 +5,7 @@ graph TD
     ITensorNetworksNext(ITensorNetworksNext.jl) --> ITensorBase(ITensorBase.jl)
     ITensorNetworksNext --> DataGraphs(DataGraphs.jl)
     DataGraphs --> NamedGraphs(NamedGraphs.jl)
-    ITensorBase --> NamedDimsArrays(NamedDimsArrays.jl)
-    NamedDimsArrays --> SparseArraysBase(SparseArraysBase.jl)
-    NamedDimsArrays --> DiagonalArrays(DiagonalArrays.jl)
-    NamedDimsArrays --> BlockSparseArrays(BlockSparseArrays.jl)
-    NamedDimsArrays --> GradedArrays(GradedArrays.jl)
-    NamedDimsArrays --> FusionTensors(FusionTensors.jl)
-    FusionTensors --> GradedArrays
-    GradedArrays --> BlockSparseArrays
-    BlockSparseArrays --> SparseArraysBase
-    BlockSparseArrays --> DiagonalArrays
-    DiagonalArrays --> SparseArraysBase
+    ITensorBase --> TensorAlgebra(TensorAlgebra.jl)
+    GradedArrays(GradedArrays.jl) --> TensorAlgebra
+    GradedArrays --> SparseArraysBase(SparseArraysBase.jl)
 ```


### PR DESCRIPTION
## Summary

Trims the navigation and ecosystem overview to the packages we surface to external users. The "Array Libraries" and "Symmetric Tensors" dropdowns are merged into a single "Tensor Libraries" group holding `ITensorBase`, `TensorAlgebra`, `GradedArrays`, and `SparseArraysBase`, and the packages that are internal building blocks or deprecated are dropped from the nav: `NamedDimsArrays`, `BlockSparseArrays`, `DiagonalArrays`, `KroneckerArrays`, `FusionTensors`, `FunctionImplementations`, `TypeParameterAccessors`, `MapBroadcast`, and `BackendSelection`. The ecosystem overview graph is redrawn over the same trimmed set.

The Upgrade Guide is kept in source but left out of the rendered navigation until it gets a rewrite to match the current API.