### PR TITLE
Add ITensorFormatter to developer tools and simplify the ecosystem graph

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorDocsNext"
 uuid = "701fd796-f527-45da-9a53-2681c1a90c45"
-version = "0.1.17"
+version = "0.1.18"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -66,7 +66,8 @@ docs = [
         "Graph Libraries", itensor_multidocref.(["NamedGraphs", "DataGraphs"])
     ),
     MultiDocumenter.DropdownNav(
-        "Developer Tools", itensor_multidocref.(["ITensorPkgSkeleton"])
+        "Developer Tools",
+        itensor_multidocref.(["ITensorPkgSkeleton", "ITensorFormatter"])
     ),
 ]
 

--- a/docs/src/ecosystem_overview.md
+++ b/docs/src/ecosystem_overview.md
@@ -7,5 +7,4 @@ graph TD
     DataGraphs --> NamedGraphs(NamedGraphs.jl)
     ITensorBase --> TensorAlgebra(TensorAlgebra.jl)
     GradedArrays(GradedArrays.jl) --> TensorAlgebra
-    GradedArrays --> SparseArraysBase(SparseArraysBase.jl)
 ```


### PR DESCRIPTION
## Summary

Adds `ITensorFormatter` to the Developer Tools navigation dropdown alongside `ITensorPkgSkeleton`. It has a published docs site and is a tool people use when developing ITensor packages, so it belongs in that group.

Also drops `SparseArraysBase` from the ecosystem overview graph, since it's an implementation detail of `GradedArrays` rather than something most users interact with when using the common features. Removing it also cleans up the layout: `GradedArrays` now sits directly above `TensorAlgebra` instead of being pulled to the side, so its edge no longer crosses the `DataGraphs` to `NamedGraphs` branch. `SparseArraysBase` stays in the Tensor Libraries dropdown for anyone who wants to find it.

Follow-up to https://github.com/ITensor/ITensorDocsNext.jl/pull/56.