### PR TITLE
Order ITensorFormatter before ITensorPkgSkeleton in developer tools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorDocsNext"
 uuid = "701fd796-f527-45da-9a53-2681c1a90c45"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["ITensor developers <support@itensor.org> and contributors"]
 
 [workspace]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -67,7 +67,7 @@ docs = [
     ),
     MultiDocumenter.DropdownNav(
         "Developer Tools",
-        itensor_multidocref.(["ITensorPkgSkeleton", "ITensorFormatter"])
+        itensor_multidocref.(["ITensorFormatter", "ITensorPkgSkeleton"])
     ),
 ]
 


### PR DESCRIPTION
## Summary

Lists `ITensorFormatter` first in the Developer Tools dropdown. The formatter runs on every PR, while `ITensorPkgSkeleton` only comes up when creating a new package, so the more commonly used tool goes on top.

Follow-up to https://github.com/ITensor/ITensorDocsNext.jl/pull/57.